### PR TITLE
Convert Spotify's remix naming convention to more widely used convention

### DIFF
--- a/spotify-sync.py
+++ b/spotify-sync.py
@@ -63,7 +63,7 @@ def getPlexTracks(plex: PlexServer, spotifyTracks: []) -> List[Track]:
         track_options = [track['name']]
         
         # Parse remixes properly
-        mix_search = re.search('(.*) - (.*Remix|Original Mix)', track_options[0], re.IGNORECASE)
+        mix_search = re.search('(.*) - (.*Remix|.*Mix)', track_options[0], re.IGNORECASE)
         if mix_search:
             track_options[0] = mix_search.group(1) + ' (' + mix_search.group(2) + ')'
             # Also match the track without "Original Mix" as this is rarely specified except in Spotify

--- a/spotify-sync.py
+++ b/spotify-sync.py
@@ -18,7 +18,7 @@ def filterPlexArray(plexItems=[], song="", artist="") -> List[Track]:
             plexItems.remove(item)
             continue
         artistItem = item.artist()
-        if artistItem.title.lower() != artist.lower():
+        if str(item.originalTitle).lower() != artist.lower() and artistItem.title.lower() != artist.lower():
             plexItems.remove(item)
             continue
 
@@ -69,20 +69,22 @@ def getPlexTracks(plex: PlexServer, spotifyTracks: []) -> List[Track]:
 
         logging.info("Searching Plex for: %s by %s" % (track_name, track['artists'][0]['name']))
 
-        try:
-            musicTracks = plex.search(track_name, mediatype='track')
-        except:
+        for artist in track['artists']:
             try:
                 musicTracks = plex.search(track_name, mediatype='track')
             except:
-                logging.info("Issue making plex request")
-                continue
-
-        if len(musicTracks) > 0:
-            plexMusic = filterPlexArray(musicTracks, track_name, track['artists'][0]['name'])
-            if len(plexMusic) > 0:
-                logging.info("Found Plex Song: %s by %s" % (track_name, track['artists'][0]['name']))
-                plexTracks.append(plexMusic[0])
+                try:
+                    musicTracks = plex.search(track_name, mediatype='track')
+                except:
+                    logging.info("Issue making plex request")
+                    break
+            if len(musicTracks) > 0:
+                plexMusic = filterPlexArray(musicTracks, track_name, artist['name'])
+                if len(plexMusic) > 0:
+                    logging.info("Found Plex Song: %s by %s" % (track_name, artist['name']))
+                    plexTracks.append(plexMusic[0])
+                    break
+                    
     return plexTracks
 
 

--- a/spotify-sync.py
+++ b/spotify-sync.py
@@ -93,7 +93,7 @@ def getPlexTracks(plex: PlexServer, spotifyTracks: []) -> List[Track]:
 
 
 def createPlaylist(plex: PlexServer, sp: spotipy.Spotify, playlist: []):
-    playlistName = playlist['owner']['display_name'] + " - " + playlist['name']
+    playlistName = playlist['owner']['id'] + " - " + playlist['name']
     logging.info('Starting playlist %s' % playlistName)
     plexTracks = getPlexTracks(plex, getSpotifyTracks(sp, playlist))
     if len(plexTracks) > 0:

--- a/spotify-sync.py
+++ b/spotify-sync.py
@@ -60,21 +60,28 @@ def getPlexTracks(plex: PlexServer, spotifyTracks: []) -> List[Track]:
     plexTracks = []
     for spotifyTrack in spotifyTracks:
         track = spotifyTrack['track']
-        logging.info("Searching Plex for: %s by %s" % (track['name'], track['artists'][0]['name']))
+        track_name = track['name']
+        
+        # Parse remixes properly
+        mix_search = re.search('(.*) - (.*Remix|Original Mix)', track_name, re.IGNORECASE)
+        if mix_search:
+            track_name = mix_search.group(1) + ' (' + mix_search.group(2) + ')'
+
+        logging.info("Searching Plex for: %s by %s" % (track_name, track['artists'][0]['name']))
 
         try:
-            musicTracks = plex.search(track['name'], mediatype='track')
+            musicTracks = plex.search(track_name, mediatype='track')
         except:
             try:
-                musicTracks = plex.search(track['name'], mediatype='track')
+                musicTracks = plex.search(track_name, mediatype='track')
             except:
                 logging.info("Issue making plex request")
                 continue
 
         if len(musicTracks) > 0:
-            plexMusic = filterPlexArray(musicTracks, track['name'], track['artists'][0]['name'])
+            plexMusic = filterPlexArray(musicTracks, track_name, track['artists'][0]['name'])
             if len(plexMusic) > 0:
-                logging.info("Found Plex Song: %s by %s" % (track['name'], track['artists'][0]['name']))
+                logging.info("Found Plex Song: %s by %s" % (track_name, track['artists'][0]['name']))
                 plexTracks.append(plexMusic[0])
     return plexTracks
 

--- a/spotify-sync.py
+++ b/spotify-sync.py
@@ -60,7 +60,7 @@ def getPlexTracks(plex: PlexServer, spotifyTracks: []) -> List[Track]:
     plexTracks = []
     for spotifyTrack in spotifyTracks:
         track = spotifyTrack['track']
-        track_options[0] = track['name']
+        track_options = [track['name']]
         
         # Parse remixes properly
         mix_search = re.search('(.*) - (.*Remix|Original Mix)', track_options[0], re.IGNORECASE)
@@ -68,7 +68,7 @@ def getPlexTracks(plex: PlexServer, spotifyTracks: []) -> List[Track]:
             track_options[0] = mix_search.group(1) + ' (' + mix_search.group(2) + ')'
             # Also match the track without "Original Mix" as this is rarely specified except in Spotify
             if mix_search.group(2) == "Original Mix":
-                track_options[1] = mix_search.group(1)
+                track_options.append(mix_search.group(1))
 
         logging.info("Searching Plex for: %s by %s" % (track_options[0], track['artists'][0]['name']))
 


### PR DESCRIPTION
Converts track titles that follow Spotify's convention for remixes 'track - remixer Remix' to a more common convention 'track (remixer Remix)'
Does the same to "Original Mix"

Doesn't totally close out #6 - ideally it would _also_ search using the original naming convention and the track title without "Original Mix".